### PR TITLE
Test if BOOT_PATH and ROOT_PATH are unset rather than their default values

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -6,6 +6,12 @@ set -o errexit
 UPDATE=${UPDATE:-1}
 UPDATE_URI="https://github.com/Hexxeh/rpi-update/raw/master/rpi-update"
 
+if [[ ${BOOT_PATH:-"unset"} == "unset" && ${ROOT_PATH:-"unset"} != "unset" ]] ||
+[[ ${BOOT_PATH:-"unset"} != "unset" && ${ROOT_PATH:-"unset"} == "unset" ]]; then
+	echo "You need to specify both ROOT_PATH and BOOT_PATH, or neither"
+	exit 1
+fi
+
 ROOT_PATH=${ROOT_PATH:-"/"}
 BOOT_PATH=${BOOT_PATH:-"/boot"}
 SKIP_KERNEL=${SKIP_KERNEL:-0}
@@ -165,12 +171,6 @@ fi
 if [[ ${UPDATE} -ne 0 ]]; then
 	echo "Raspberry Pi firmware updater by Hexxeh, enhanced by AndrewS"
 	update_self
-fi
-
-if [[ ( "${ROOT_PATH}" == "/"  &&  "${BOOT_PATH}" != "/boot" ) ]] ||
-[[ ( "${BOOT_PATH}" == "/boot"  &&  "${ROOT_PATH}" != "/" ) ]]; then
-	echo "You need to specify both ROOT_PATH and BOOT_PATH, or neither"
-	exit 1
 fi
 
 if [[ ! -d "${FW_PATH}" ]]; then


### PR DESCRIPTION
Fixes hexxeh/rpi-update #11 by checking if values are unset before setting them to defaults, rather than checking the values are the same as the defaults, as that causes problems with a ROOT_PATH of / and any BOOT_PATH besides the default (also the other way with a BOOT_PATH of /boot and a ROOT_PATH that is not / but anyone doing that is nuts anyway)...
