### PR TITLE
Insecure tmp file handling

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -42,7 +42,7 @@ function update_self() {
 		exit 1
 	fi
 
-	cat > /tmp/updateScript.sh << EOF
+	cat > /root/.updateScript.sh << EOF
 	#!/bin/bash
 	if mv "${_tempFileName}" "$0"; then
 		rm -- "\$0"
@@ -53,7 +53,7 @@ function update_self() {
 EOF
 
 	echo " *** Relaunching after update"
-	exec /bin/bash /tmp/updateScript.sh
+	exec /bin/bash /root/.updateScript.sh
 }
 
 function update_modules {


### PR DESCRIPTION
A malicious user can clobber any file due to insecure tmp file handling. Example:

pi@raspberrypi ~ $ ln -s /etc/passwd /tmp/updateScript.sh
pi@raspberrypi ~ $ sudo rpi-update
...
pi@raspberrypi ~ $ cat /etc/passwd
# !/bin/bash

if mv "./testfile.sh.tmp" "./testfile.sh"; then
rm -- "$0"
exec env UPDATE_SELF=0 /bin/bash "./testfile.sh" ""
else
echo " !!! Failed!"
fi

As of this point, the pi is quite unusable.

As there are already references in the code to data stored in the root user's home directory, I have replicated that configuration in this patch.
