### PR TITLE
Updates .firmware_revision when revision set at CLI

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -107,7 +107,9 @@ function finalise {
 	if [[ ${FW_REV} == "" ]]; then
 		echo " *** Storing current firmware revision"
 		eval ${GITCMD} rev-parse master > "${FW_PATH}/.firmware_revision"
-	fi
+  else
+    echo ${FW_REV} > "${FW_PATH}/.firmware_revision"
+  fi
 	echo " *** Syncing changes to disk"
 	sync
 }


### PR DESCRIPTION
When revision was specified at the command line,
$FW_PATH/.firmware_updating wasn't updated to reflect the change.
Now $FW_PATH/.firmware_updating is always updated, so idempotency is
achieved when using revision Id's at the command line.
Fixes #84

Tested successfully here :

```
root@rasp:~# cat /boot/.firmware_revision                                                                          
7d7f8510f103f3c6686835c0a002de038da0946f
root@rasp:~# UPDATE_SELF=0 rpi-update 0fc090e8fbae693fae12bdf26b59c812ba99e141
   *** Raspberry Pi firmware updater by Hexxeh, enhanced by AndrewS
   *** ARM/GPU split is now defined in /boot/config.txt using the gpu_mem option!
   *** Downloading specific firmware revision (this will take a few minutes)
  --2013-04-11 14:32:58--  http://github.com/Hexxeh/rpi-firmware/tarball/0fc090e8fbae693fae12bdf26b59c812ba99e141
  Resolving github.com (github.com)... 204.232.175.90
  Connecting to github.com (github.com)|204.232.175.90|:80... connected.
  ...
   *** Running ldconfig
   *** Syncing changes to disk
   *** If no errors appeared, your firmware was successfully updated to revision 0fc090e8fbae693fae12bdf26b59c812ba99
   *** A reboot is needed to activate the new firmware
  root@rasp:~# cat /boot/.firmware_revision
  0fc090e8fbae693fae12bdf26b59c812ba99e141
```

Thanks !
