### PR TITLE
BRANCH env variable allows alternate branch to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ are not currently booted from. Useful for installing firmware/kernel to a
 non-RPI customised image. Be careful, you must specify both options or neither.
 Specifying only one will not work.
 
+#### `BRANCH`
+
+By default, clones the firmware files from the master branch, else uses the files
+from the specified branch, eg:
+
+    sudo BRANCH=next rpi-update
+
+will use the 'next' branch.
+
 #### Troubleshooting
 
 There are two possible problems related to SSL certificates that may prevent

--- a/rpi-update
+++ b/rpi-update
@@ -14,6 +14,7 @@ if [[ ${BOOT_PATH:-"unset"} == "unset" && ${ROOT_PATH:-"unset"} != "unset" ]] ||
 	exit 1
 fi
 
+BRANCH=${BRANCH:-"master"}
 ROOT_PATH=${ROOT_PATH:-"/"}
 BOOT_PATH=${BOOT_PATH:-"/boot"}
 SKIP_KERNEL=${SKIP_KERNEL:-0}
@@ -106,7 +107,7 @@ function finalise {
 	ldconfig -r "${ROOT_PATH}"
 	if [[ ${FW_REV} == "" ]]; then
 		echo " *** Storing current firmware revision"
-		eval ${GITCMD} rev-parse master > "${FW_PATH}/.firmware_revision"
+		eval ${GITCMD} rev-parse ${BRANCH} > "${FW_PATH}/.firmware_revision"
   else
     echo ${FW_REV} > "${FW_PATH}/.firmware_revision"
   fi
@@ -118,7 +119,7 @@ function download_repo {
 	echo " *** Setting up firmware (this may take a few minutes)"
 	mkdir -p "${FW_REPOLOCAL}"
 	set +e
-	git clone "${FW_REPO}" "${FW_REPOLOCAL}" --depth=1
+	git clone "${FW_REPO}" "${FW_REPOLOCAL}" --depth=1 --branch ${BRANCH}
 	RETVAL=$?
 	set -e
 	if [[ ${RETVAL} -ne 0 ]]; then


### PR DESCRIPTION
Allow bleeding-edge users to choose which branch to use to fetch firmware updates from by setting the BRANCH env variable. For example, to test out the 3.8.8 kernel:

```
sudo BRANCH=next rpi-update
```

And then the revert back to the default branch (='master')  (3.6.11 kernel)

```
sudo rpi-update
```
