### PR TITLE
rpi-update incorrectly detects latest git commit when called with BRANCH=next

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -201,7 +201,7 @@ if [[ ${FW_REV} != "" ]]; then
 	do_update "updated to revision ${FW_REV}"
 elif [[ -f "${FW_REPOLOCAL}/.git/config" ]]; then
 	# ask git server version before spending time cloning
-	GITREV=$(git ls-remote -h ${REPO_URI} refs/heads/master | awk '{print $1}')
+	GITREV=$(git ls-remote -h ${REPO_URI} refs/heads/${BRANCH} | awk '{print $1}')
 	if [[ -f "${FW_PATH}/.firmware_revision" ]] && [[ $(cat "${FW_PATH}/.firmware_revision") == "$GITREV" ]]; then
 		echo " *** Your firmware is already up to date"
 		# no changes made, nothing to finalise


### PR DESCRIPTION
"BRANCH=next rpi-update" will always fetch the latest git commit from the next branch, and re-downloads everything even if the local firmware git repo is up to date (which is annoying since rpi-update from the master branch of the firmware repo doesn't have this problem). The root cause is that the master branch is hardcoded into the git revision check:

GITREV=$(git ls-remote -h ${REPO_URI} refs/heads/master | awk '{print $1}')

This pull request fixes this issue (I tested with UPDATE_SELF=0 after modifying the script, and it works). Thanks!
