### PR TITLE
Updated to not require /lib/modules

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -139,7 +139,9 @@ function do_backup {
 	rm -rf "${FW_PATH}.bak"
 	cp -va "${FW_PATH}" "${FW_PATH}.bak"
 	rm -rf "${FW_MODPATH}.bak"
-	cp -va "${FW_MODPATH}" "${FW_MODPATH}.bak"
+	if [[ ${SKIP_KERNEL} -eq 0 ]]; then
+		cp -va "${FW_MODPATH}" "${FW_MODPATH}.bak"
+	fi
 }
 
 function do_update {


### PR DESCRIPTION
This seems to work as expected. I suppose the SKIP_KERNEL check could be above rm -rf "${FW_MODPATH}.bak" in do_backup function.
