### PR TITLE
Remove $GITCMD variable

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -106,7 +106,7 @@ function finalise {
 	ldconfig -r "${ROOT_PATH}"
 	if [[ ${FW_REV} == "" ]]; then
 		echo " *** Storing current firmware revision"
-		git --git-dir="${FW_REPOLOCAL}/.git" --work-tree="${FW_REPOLOCAL}" rev-parse ${BRANCH} > "${FW_REVFILE}"
+		git --git-dir="${FW_REPOLOCAL}/.git" rev-parse ${BRANCH} > "${FW_REVFILE}"
 	else
 		echo ${FW_REV} > "${FW_REVFILE}"
 	fi


### PR DESCRIPTION
After commit c5d159c $GITCMD is only used once, so 'inline it', which also allows us to get rid of the 'eval' call.
