### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To install the tool, run the following command:
 
 To install the tool, run the following command:
 
-    sudo curl -L --output /usr/bin/rpi-update https://raw.github.com/Hexxeh/rpi-update/master/rpi-update && sudo chmod +x /usr/bin/rpi-update
+    sudo curl -L --output /usr/bin/rpi-update https://raw.githubusercontent.com/Hexxeh/rpi-update/master/rpi-update && sudo chmod +x /usr/bin/rpi-update
 
 ## Updating
 


### PR DESCRIPTION
Upon installation of the tool, the command executed writes rpi-update to /usr/bin detailing a 301 error, indicating the source of the update has changed to https://raw.githubusercontent.com/Hexxeh/rpi-update/master/rpi-update. This address change has been reflected in the proposed file change.
