### PR TITLE
Stop rpi-update deleting dt-blob.bin

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -101,7 +101,7 @@ function update_sdk {
 function update_firmware {
 	echo " *** Updating firmware"
 	rm -rf "${FW_PATH}/"*.elf
-	rm -rf "${FW_PATH}/"*.bin
+	rm -rf "${FW_PATH}/"bootcode.bin
 	cp "${FW_REPOLOCAL}/"*.elf "${FW_PATH}/"
 	cp "${FW_REPOLOCAL}/"*.bin "${FW_PATH}/"
 	cp "${FW_REPOLOCAL}/"*.dat "${FW_PATH}/"


### PR DESCRIPTION
dt-blob.bin is used to configure a platform's pin settings and clock settings and must not be changed when we do an rpi-update.  This is a function of the platform rather than a function of the operating system and therefore shouldn't be removed
