### PR TITLE
Fix output of commit messages - kind of

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -345,7 +345,7 @@ else
 		echo " *** Firmware update required. New commits available:"
 		DIFF_API=${REPO_URI/github.com/api.github.com\/repos}/compare/$(cat "${FW_REVFILE}")...${BRANCH}
 		SEPARATOR="======================================================"
-		curl -Ls ${DIFF_API} | awk -v SEPARATOR="${SEPARATOR}" -F\" ' { if ($2 == "commits") {commits=1} if (commits && $2 == "message") {print SEPARATOR "\n" $4} }' | sed 's/\\n/\n/g'
+		curl -Ls ${DIFF_API} | awk -v SEPARATOR="${SEPARATOR}" -F\" ' { if ($2 == "commits") {commits=1} if (commits && $2 == "message") {print SEPARATOR "\nCommit: " $4} }' | sed 's/\\n\\n/\nCommit:\ /g'
 		exit 2
 	fi
 fi


### PR DESCRIPTION
This fixes unnecessary newlines and prints one commit per line. An additional prefix of "Commit: " is added to make grepping for the count of new commits possible for external scripts that take the output of rpi-update as input (I am currently writing a Nagios/Icinga check that makes it possible to monitor how many commits one is behind the chosen ${BRANCH}).

That being said, I find the current way of collecting the commits between the status quo and ${BRANCH} master to be kind of fragile. I may fix this another time.