### PR TITLE
Nullify user-defined --write-out option in cURL

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,0 @@
-##########################################################
-#### WhiteSource "Bolt for Github" configuration file ####
-##########################################################
-
-# Configuration #
-#---------------#
-ws.repo.scan=true
-vulnerable.check.run.conclusion.level=success

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+##########################################################
+#### WhiteSource "Bolt for Github" configuration file ####
+##########################################################
+
+# Configuration #
+#---------------#
+ws.repo.scan=true
+vulnerable.check.run.conclusion.level=success

--- a/rpi-update
+++ b/rpi-update
@@ -293,7 +293,7 @@ function download_rev {
 		echo " *** Downloading specific firmware revision (this will take a few minutes)"
 		rm -rf "${FW_REPOLOCAL}"
 		mkdir -p "${FW_REPOLOCAL}"
-		eval curl -L ${GITHUB_AUTH_PARAM} "${REPO_URI}/tarball/${FW_REV}" | tar xzf - -C "${FW_REPOLOCAL}" --strip-components=1
+		eval curl -w "" -L ${GITHUB_AUTH_PARAM} "${REPO_URI}/tarball/${FW_REV}" | tar xzf - -C "${FW_REPOLOCAL}" --strip-components=1
 	fi
 }
 


### PR DESCRIPTION
I believe the issues #174, #250, #253 all relates to the `--write-out` option for cURL being set in the machine's user's `~/.curlrc` file. This will append strings to the end of `stdout` which gets piped into `tar`. `tar` will then complain that the archive file is corrupted.

See my [comment](https://github.com/Hexxeh/rpi-update/issues/253#issuecomment-405045193) for more details.