### PR TITLE
Use jq instead of awk for the reading of json data from Github API

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -55,9 +55,9 @@ if [[ -n "${GITHUB_API_TOKEN}" ]]; then
 	GITHUB_AUTH_PARAM="--header \"Authorization: token ${GITHUB_API_TOKEN}\""
 fi
 
-GITHUB_API_LIMITED=$(eval curl -Ls ${GITHUB_AUTH_PARAM} https://api.github.com/rate_limit | tr -d "," | awk 'BEGIN {reset=0;} { if ($1 == "\"limit\":") limit=$2; else if ($1 == "\"remaining\":") remaining=$2; else if ($1 == "\"reset\":" && limit>0 && remaining==0) reset=$2;} END { print reset }')
-if [ ${GITHUB_API_LIMITED} -gt 0 ]; then
-	echo " *** Github api is currently rate limited - please try again after $(date --date @${GITHUB_API_LIMITED})"
+GITHUB_API_LIMITED=($(eval curl -Ls ${GITHUB_AUTH_PARAM} https://api.github.com/rate_limit  | jq '.["resources"]["core"]["remaining", "reset"]'))
+if [ ${GITHUB_API_LIMITED[0]} -eq 0 ]; then
+	echo " *** Github api is currently rate limited - please try again after $(date --date @${GITHUB_API_LIMITED[1]})"
 	exit 1
 fi
 
@@ -346,7 +346,7 @@ function noobs_fix {
 
 function get_hash_date {
 	commit_api="https://api.github.com/repos/Hexxeh/rpi-firmware/git/commits/"
-	eval curl -Ls ${GITHUB_AUTH_PARAM} "$commit_api"$1 | grep "date" | head -1 | awk -F\" '{print $4}'
+	eval curl -Ls ${GITHUB_AUTH_PARAM} "$commit_api"$1 | jq '.author.date' |tr -d '"'
 }
 
 function compare_hashes {
@@ -362,7 +362,7 @@ function compare_hashes {
 function get_long_hash {
 	# ask github for long version hash
 	local REPO_API=${REPO_URI/github.com/api.github.com\/repos}/commits/$1
-	eval curl -Ls ${GITHUB_AUTH_PARAM} ${REPO_API} | awk 'BEGIN {hash=""} { if (hash == "" && $1 == "\"sha\":") {hash=substr($2, 2, 40);} } END {print hash}'
+	eval curl -Ls ${GITHUB_AUTH_PARAM} ${REPO_API} | jq '.sha' | tr -d '"'
 }
 
 
@@ -403,6 +403,13 @@ command -v readelf >/dev/null 2>&1 || {
 	exit 1
 }
 
+command -v jq >/dev/null 2>&1 || {
+	echo " !!! This tool requires you have jq installed, please install it first"
+	echo "     In Debian, try: sudo apt-get install jq"
+	echo "     In Arch, try: pacman -S jq"
+	exit 1
+}
+
 if [[ "${FW_REV_IN}" == "" ]]; then
 	FW_REV_IN=${BRANCH}
 fi
@@ -435,8 +442,9 @@ else
 			echo " *** Firmware downgrade requested. Commits to drop:"
 			DIFF_API=${REPO_URI/github.com/api.github.com\/repos}/compare/${FW_REV}...${LOCAL_HASH}
 		fi
-		SEPARATOR="======================================================"
-		eval curl -Ls ${GITHUB_AUTH_PARAM} ${DIFF_API} | awk -v SEPARATOR="${SEPARATOR}" -F\" ' { if ($2 == "commits") {commits=1} if (commits && $2 == "message") {print SEPARATOR "\nCommit: " $4} }' | sed 's/\\n\\n/\nCommit:\ /g'
+		SEPARATOR="=============================
+		echo " "========================="
+		eval curl -Ls ${GITHUB_AUTH_PARAM} ${DIFF_API} | jq . -M | awk -v SEPARATOR="${SEPARATOR}" -F\" ' { if ($2 == "commits") {commits=1} if (commits && $2 == "message") {print SEPARATOR "\nCommit: " $4} }' | sed 's/\\n\\n/\nCommit:\ /g'
 		exit 2
 	fi
 fi


### PR DESCRIPTION
Github seems to have changed the json output format of its API endpoints (removing newlines) which breaks the current _curl pipe awk_ parsing used currently to handle a number of things. It's likely this could be fixed with awk, but I think a json-native parsing makes things more durable.
Please note that this change makes the _jq_ utility a requirement for using rpi-update.