### PR TITLE
Skip check partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ To reboot after successfully update, run:
 
 You can use it to automate updates.
 
+#### `WANT_PI4`
+
+To explicitly request an update comprehensive of Rasberry PI 4 files, run:
+
+    sudo WANT_PI4=1 rpi-update
+
+This will download suitable environments for all Raspberry PI models.
+
+#### `SKIP_CHECK_PARTITION`
+
+To skip the boot partition size check when installing Raspberry PI 4 files, run:
+
+    sudo SKIP_CHECK_PARTITION=1 rpi-update
+
+Note that a 256M FAT boot partition is recommended, any less could result in a system that will not boot.
+
 ## Troubleshooting
 
 There are two possible problems related to SSL certificates that may prevent

--- a/rpi-update
+++ b/rpi-update
@@ -36,6 +36,7 @@ SKIP_DOWNLOAD=${SKIP_DOWNLOAD:-0}
 SKIP_WARNING=${SKIP_WARNING:-0}
 WANT_SYMVERS=${WANT_SYMVERS:-0}
 WANT_PI4=${WANT_PI4:-0}
+SKIP_CHECK_PARTITION=${SKIP_CHECK_PARTITION:-0}
 PRUNE_MODULES=${PRUNE_MODULES:-0}
 RPI_UPDATE_UNSUPPORTED=${RPI_UPDATE_UNSUPPORTED:-0}
 JUST_CHECK=${JUST_CHECK:-0}
@@ -314,7 +315,7 @@ function do_update {
 	if [ -f ${FW_PATH}/kernel7l.img ]; then
 		WANT_PI4=1
 	fi
-	if [[ ${WANT_PI4} -eq 1 ]]; then
+	if [[ ${WANT_PI4} -eq 1 ]] && [[ ${SKIP_CHECK_PARTITION} -eq 0 ]]; then
 		check_partition
 	fi
 	show_notice


### PR DESCRIPTION
This allows to skip the partition size check when installing PI4 files. I've also took the chance to update the README file.