### PR TITLE
Allow user to skip updating VideoCore libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Avoids making backup of /boot and /lib/modules on first run.
 By default the downloaded files (/root/.rpi-firmware) are deleted at end of update.
 Use this option to keep the files.
 
+#### `SKIP_VCLIBS`
+
+    sudo SKIP_VCLIBS=1 rpi-update
+
+Will update everything **except** the VideoCore libraries.
+Use this option to keep the existing VideoCore libraries if you do not want your
+local versions overwritten.
+
 #### `ROOT_PATH` and `BOOT_PATH`
 
     sudo ROOT_PATH=/media/root BOOT_PATH=/media/boot rpi-update

--- a/rpi-update
+++ b/rpi-update
@@ -30,6 +30,7 @@ BOOT_PATH=${BOOT_PATH:-"/boot"}
 WORK_PATH=${WORK_PATH:-"${ROOT_PATH}/root"}
 SKIP_KERNEL=${SKIP_KERNEL:-0}
 SKIP_SDK=${SKIP_SDK:-0}
+SKIP_VCLIBS=${SKIP_VCLIBS:-0}
 SKIP_REPODELETE=${SKIP_REPODELETE:-0}
 SKIP_BACKUP=${SKIP_BACKUP:-0}
 SKIP_DOWNLOAD=${SKIP_DOWNLOAD:-0}
@@ -151,7 +152,12 @@ function update_modules {
 }
 
 function update_vc_libs {
-	echo " *** Updating VideoCore libraries"
+	if [[ ${SKIP_VCLIBS} -eq 0 ]]; then
+		echo " *** Updating VideoCore libraries"
+	else
+		echo " *** As requested, not updating VideoCore libraries"
+		return
+	fi
 
 	if [[ -e ${ROOT_PATH}/bin/sh ]]; then
 		local ELFOUTPUT=$(readelf -a "${ROOT_PATH}/bin/sh"; readelf -h "${ROOT_PATH}/bin/sh")


### PR DESCRIPTION
Users who are running non-raspbian distributions, especially on other architectures
like arm64, may already have videocore libraries and applications compiled for arm64.
These will get overwritten unless updating the VideoCore libraries is skipped.

This implements a SKIP_VCLIBS option to allow that step to be skipped, which may be 
used alongside the SKIP_SDK option. This is also referred to in a suggestion for a
SKIP_USERLAND option here: https://github.com/Hexxeh/rpi-update/pull/221#issuecomment-243559009

Signed-off-by: Satadru Pramanik <satadru@umich.edu>