### PR TITLE
Support FW_SUBDIR a.k.a. os_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ are not currently booted from. Useful for installing firmware/kernel to a
 non-RPI customised image. Be careful, you must specify both options or neither.
 Specifying only one will not work.
 
+#### `FW_SUBDIR`
+
+    sudo FW_SUBDIR=safe rpi-update
+
+Allows the firmware to be installed to a subdirectory of /boot. This feature is
+intended to support the `os_prefix` setting that can be used in `config.txt`.
+By default, FW_SUBDIR is initialised to the value of `os_prefix` in effect when
+the device was booted, so as to overwrite the "running" firmware. To explicitly
+install with no subdirectory (to install into /boot), use `FW_SUBDIR=/`.
+
 #### `BRANCH`
 
 By default, clones the firmware files from the master branch, else uses the files

--- a/rpi-update
+++ b/rpi-update
@@ -26,7 +26,7 @@ fi
 
 BRANCH=${BRANCH:-"master"}
 ROOT_PATH=${ROOT_PATH:-"/"}
-CUR_FW_SUBDIR="/$(vcgencmd get_config os_prefix | cut -d'=' -f2)"
+CUR_FW_SUBDIR="/$(echo =$(vcgencmd get_config os_prefix) | cut -d'=' -f3)"
 FW_SUBDIR=${FW_SUBDIR:-${CUR_FW_SUBDIR}}
 if [[ "${FW_SUBDIR}" != "" ]]; then
 	if [[ "${FW_SUBDIR::1}" != "/" ]]; then
@@ -380,8 +380,7 @@ function finalise {
 function do_backup {
 	if [[ ${SKIP_BACKUP} -eq 0 ]]; then
 		echo " *** Backing up files (this will take a few minutes)"
-		local OLD_FW_PATH="${BOOT_PATH}.bak${FW_SUBDIR}"
-
+		local OLD_FW_PATH="${BOOT_PATH}.bak"
 		if [[ -d "${OLD_FW_PATH}" ]]; then
 			echo " *** Remove old firmware backup"
 			rm -rf "${OLD_FW_PATH}"

--- a/rpi-update
+++ b/rpi-update
@@ -26,6 +26,16 @@ fi
 
 BRANCH=${BRANCH:-"master"}
 ROOT_PATH=${ROOT_PATH:-"/"}
+CUR_FW_SUBDIR="/$(vcgencmd get_config os_prefix | cut -d'=' -f2)"
+FW_SUBDIR=${FW_SUBDIR:-${CUR_FW_SUBDIR}}
+if [[ "${FW_SUBDIR}" != "" ]]; then
+	if [[ "${FW_SUBDIR::1}" != "/" ]]; then
+		FW_SUBDIR="/$FW_SUBDIR"
+	fi
+	if [[ "${FW_SUBDIR: -1}" == "/" ]]; then
+		FW_SUBDIR=${FW_SUBDIR: : -1}
+	fi
+fi
 BOOT_PATH=${BOOT_PATH:-"/boot"}
 WORK_PATH=${WORK_PATH:-"${ROOT_PATH}/root"}
 SKIP_KERNEL=${SKIP_KERNEL:-0}
@@ -47,7 +57,7 @@ GITHUB_API_TOKEN=${GITHUB_API_TOKEN:-""}
 
 FW_REPO="${REPO_URI}.git"
 FW_REPOLOCAL=${FW_REPOLOCAL:-"${WORK_PATH}/.rpi-firmware"}
-FW_PATH="${BOOT_PATH}"
+FW_PATH="${BOOT_PATH}${FW_SUBDIR}"
 FW_MODPATH="${ROOT_PATH}/lib/modules"
 FW_REV_IN=${1:-""}
 FW_REVFILE="${FW_PATH}/.firmware_revision"
@@ -370,7 +380,8 @@ function finalise {
 function do_backup {
 	if [[ ${SKIP_BACKUP} -eq 0 ]]; then
 		echo " *** Backing up files (this will take a few minutes)"
-		local OLD_FW_PATH=${FW_PATH}.bak
+		local OLD_FW_PATH="${BOOT_PATH}.bak${FW_SUBDIR}"
+
 		if [[ -d "${OLD_FW_PATH}" ]]; then
 			echo " *** Remove old firmware backup"
 			rm -rf "${OLD_FW_PATH}"


### PR DESCRIPTION
The FW_SUBDIR environment variable is equivalent to the os_prefix config
setting, except that it is required to be the name of a directory. By
default, rpi-update will initialise FW_SUBDIR from the os_prefix setting
used to boot the device. A different subdirectory can be updated by
specifying a value for FW_SUBDIR in the environment, e.g.

    sudo FW_SUBDIR=safe rpi-update

To specify explicitly that no subdirectory is to be used, i.e. to force
installation into /boot, use FW_SUBDIR=/ .