### PR TITLE
Add message explaining how to force an update

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -592,7 +592,7 @@ if [[ ! -f "${FW_REVFILE}" ]]; then
 else
 	LOCAL_HASH=$(get_long_hash "$(cat "${FW_REVFILE}")")
 	if [[ "${LOCAL_HASH}" == "${FW_REV}" ]]; then
-		echo " *** Your firmware is already up to date. (Delete ${FW_REVFILE} to force an update anyway)"
+		echo " *** Your firmware is already up to date (delete ${FW_REVFILE} to force an update anyway)"
 		exit 0
 	fi
 	if [[ ${JUST_CHECK} -ne 0 ]]; then

--- a/rpi-update
+++ b/rpi-update
@@ -592,7 +592,7 @@ if [[ ! -f "${FW_REVFILE}" ]]; then
 else
 	LOCAL_HASH=$(get_long_hash "$(cat "${FW_REVFILE}")")
 	if [[ "${LOCAL_HASH}" == "${FW_REV}" ]]; then
-		echo " *** Your firmware is already up to date"
+		echo " *** Your firmware is already up to date. (Delete ${FW_REVFILE} to force an update anyway)"
 		exit 0
 	fi
 	if [[ ${JUST_CHECK} -ne 0 ]]; then


### PR DESCRIPTION
This should help with situations like https://github.com/raspberrypi/rpi-eeprom/issues/336 where the user runs `rpi-update` to get the "beta firmware", but then (accidentally?) runs `apt-get update && apt-get upgrade` which then updates `raspberrypi-bootloader` which overwrites the new "beta firrmware" with the older "stable firmware". If the user realises their mistake and tries running `rpi-update` again, they'll just get told "Your firmware is already up to date.".

This PR updates that message to tell the user how to "force" an rpi-update. (perhaps there's a "better" way of doing this, but this seemed like the simplest option?)