### PR TITLE
Support updating using github artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install the tool, run the following command:
 
 To install the tool, run the following command:
 
-    sudo curl -L --output /usr/bin/rpi-update https://raw.githubusercontent.com/Hexxeh/rpi-update/master/rpi-update && sudo chmod +x /usr/bin/rpi-update
+    sudo curl -L --output /usr/bin/rpi-update https://raw.githubusercontent.com/raspberrypi/rpi-update/master/rpi-update && sudo chmod +x /usr/bin/rpi-update
 
 ## Updating
 
@@ -60,7 +60,7 @@ If you'd like to set a different GPU/ARM memory split, then define `gpu_mem` in
 `/boot/config.txt`.
 
 To upgrade/downgrade to a specific firmware revision, specify its Git hash
-(from the https://github.com/Hexxeh/rpi-firmware repository) as follows:
+(from the https://github.com/raspberrypi/rpi-firmware repository) as follows:
 
     sudo rpi-update fab7796df0cf29f9563b507a59ce5b17d93e0390
 

--- a/rpi-update
+++ b/rpi-update
@@ -481,7 +481,20 @@ function do_update {
 }
 
 function download_rev {
-	if [[ ${SKIP_DOWNLOAD} -eq 0 ]]; then
+	if [[ "${ARTIFACT}" != "" ]]; then
+		if [[ ${FW_REV_IN} == http* ]]; then
+			GET="wget --no-check-certificate -qO-"
+		else
+			GET="cat"
+		fi
+		echo " *** Downloading specific firmware revision (this will take a few minutes)"
+		rm -rf "${FW_REPOLOCAL}"
+		mkdir -p "${FW_REPOLOCAL}"
+		if ! eval ${GET} "${ARTIFACT}" | zcat | tar xf - -C "${FW_REPOLOCAL}" --strip-components=2; then
+			echo "Invalid artifact specified"
+			exit 1
+		fi
+	elif [[ ${SKIP_DOWNLOAD} -eq 0 ]]; then
 		local FW_TARBALL_URI=${REPO_URI}/tarball/${FW_REV}
 		if ! eval curl -fs ${CURL_OPTIONS} --output /dev/null --head "${FW_TARBALL_URI}"; then
 			echo "Invalid git hash specified"
@@ -606,7 +619,15 @@ if [[ "${FW_REV_IN}" == "" ]]; then
 	FW_REV_IN=${BRANCH}
 fi
 
-FW_REV=$(get_long_hash "${FW_REV_IN}")
+if [[ ${FW_REV_IN} == http* ]] || [[ ${FW_REV_IN} == *.zip ]]; then
+	ARTIFACT=${FW_REV_IN}
+	FW_REV=${ARTIFACT}
+	SKIP_FIRMWARE=1
+	SKIP_SDK=1
+	SKIP_VCLIBS=1
+else
+	FW_REV=$(get_long_hash "${FW_REV_IN}")
+fi
 
 if [[ "${FW_REV}" == "" ]]; then
 	echo " *** Invalid hash given"
@@ -622,7 +643,11 @@ if [[ ! -f "${FW_REVFILE}" ]]; then
 	fi
 	do_backup
 else
-	LOCAL_HASH=$(get_long_hash "$(cat "${FW_REVFILE}")")
+	if [[ "${ARTIFACT}" != "" ]]; then
+		LOCAL_HASH=$(cat "${FW_REVFILE}")
+	else
+		LOCAL_HASH=$(get_long_hash "$(cat "${FW_REVFILE}")")
+	fi
 	if [[ "${LOCAL_HASH}" == "${FW_REV}" ]]; then
 		echo " *** Your firmware is already up to date (delete ${FW_REVFILE} to force an update anyway)"
 		exit 0

--- a/rpi-update
+++ b/rpi-update
@@ -331,11 +331,11 @@ function check_partition {
 
 function update_firmware {
 	echo " *** Updating firmware"
-	rm -rf "${FW_PATH}/"*.elf
+	rm -rf "${FW_PATH}/"start*.elf
 	rm -rf "${FW_PATH}/"bootcode.bin
 	if [[ ${WANT_PI4} -eq 1 ]]; then
-		cp "${FW_REPOLOCAL}/"*.elf "${FW_PATH}/"
-		cp "${FW_REPOLOCAL}/"*.dat "${FW_PATH}/"
+		cp "${FW_REPOLOCAL}/"start*.elf "${FW_PATH}/"
+		cp "${FW_REPOLOCAL}/"fixup*.dat "${FW_PATH}/"
 	else
 		cp "${FW_REPOLOCAL}/"start{,[^4]*}.elf "${FW_PATH}/"
 		cp "${FW_REPOLOCAL}/"fixup{,[^4]*}.dat "${FW_PATH}/"

--- a/rpi-update
+++ b/rpi-update
@@ -43,6 +43,7 @@ fi
 BOOT_PATH=${BOOT_PATH:-"/boot"}
 WORK_PATH=${WORK_PATH:-"${ROOT_PATH}/root"}
 SKIP_KERNEL=${SKIP_KERNEL:-0}
+SKIP_FIRMWARE=${SKIP_FIRMWARE:-0}
 SKIP_SDK=${SKIP_SDK:-0}
 SKIP_VCLIBS=${SKIP_VCLIBS:-0}
 SKIP_REPODELETE=${SKIP_REPODELETE:-0}
@@ -340,18 +341,20 @@ function check_partition {
 }
 
 function update_firmware {
-	echo " *** Updating firmware"
-	rm -rf "${FW_PATH}/"start*.elf
-	rm -rf "${FW_PATH}/"fixup*.dat
-	rm -rf "${FW_PATH}/"bootcode.bin
-	if [[ ${WANT_PI4} -eq 1 ]]; then
-		cp "${FW_REPOLOCAL}/"start*.elf "${FW_PATH}/"
-		cp "${FW_REPOLOCAL}/"fixup*.dat "${FW_PATH}/"
-	else
-		cp "${FW_REPOLOCAL}/"start{,[^4]*}.elf "${FW_PATH}/"
-		cp "${FW_REPOLOCAL}/"fixup{,[^4]*}.dat "${FW_PATH}/"
+	if [[ ${SKIP_FIRMWARE} -eq 0 ]]; then
+		echo " *** Updating firmware"
+		rm -rf "${FW_PATH}/"start*.elf
+		rm -rf "${FW_PATH}/"fixup*.dat
+		rm -rf "${FW_PATH}/"bootcode.bin
+		if [[ ${WANT_PI4} -eq 1 ]]; then
+			cp "${FW_REPOLOCAL}/"start*.elf "${FW_PATH}/"
+			cp "${FW_REPOLOCAL}/"fixup*.dat "${FW_PATH}/"
+		else
+			cp "${FW_REPOLOCAL}/"start{,[^4]*}.elf "${FW_PATH}/"
+			cp "${FW_REPOLOCAL}/"fixup{,[^4]*}.dat "${FW_PATH}/"
+		fi
+		cp "${FW_REPOLOCAL}/"*.bin "${FW_PATH}/"
 	fi
-	cp "${FW_REPOLOCAL}/"*.bin "${FW_PATH}/"
 	if [[ ${SKIP_KERNEL} -eq 0 ]]; then
 		if [[ ${WANT_32BIT} -eq 1 ]]; then
 			cp "${FW_REPOLOCAL}/"kernel.img "${FW_REPOLOCAL}/"kernel7.img "${FW_PATH}/"

--- a/rpi-update
+++ b/rpi-update
@@ -357,13 +357,14 @@ function update_firmware {
 	fi
 	if [[ ${SKIP_KERNEL} -eq 0 ]]; then
 		if [[ ${WANT_32BIT} -eq 1 ]]; then
-			cp "${FW_REPOLOCAL}/"kernel.img "${FW_REPOLOCAL}/"kernel7.img "${FW_PATH}/"
+			[[ -e "${FW_REPOLOCAL}/"kernel.img ]] && cp "${FW_REPOLOCAL}/"kernel.img "${FW_PATH}/"
+			[[ -e "${FW_REPOLOCAL}/"kernel7.img ]] && cp "${FW_REPOLOCAL}/"kernel7.img "${FW_PATH}/"
 			if [[ ${WANT_PI4} -eq 1 ]]; then
-				cp "${FW_REPOLOCAL}/"kernel7l.img "${FW_PATH}/"
+				[[ -e "${FW_REPOLOCAL}/"kernel7l.img ]] && cp "${FW_REPOLOCAL}/"kernel7l.img "${FW_PATH}/"
 			fi
 		fi
 		if [[ ${WANT_64BIT} -eq 1 ]]; then
-			cp "${FW_REPOLOCAL}/"kernel8.img "${FW_PATH}/"
+			[[ -e "${FW_REPOLOCAL}/"kernel8.img ]] && cp "${FW_REPOLOCAL}/"kernel8.img "${FW_PATH}/"
 		fi
 		if [[ -n $(shopt -s nullglob; echo "${FW_REPOLOCAL}/"*.dtb*) ]]; then
 			cp "${FW_REPOLOCAL}/"*.dtb* "${FW_PATH}/"

--- a/rpi-update
+++ b/rpi-update
@@ -26,7 +26,11 @@ fi
 
 BRANCH=${BRANCH:-"master"}
 ROOT_PATH=${ROOT_PATH:-"/"}
-CUR_FW_SUBDIR="/$(echo =$(vcgencmd get_config os_prefix) | cut -d'=' -f3)"
+if command -v vcgencmd > /dev/null; then
+	CUR_FW_SUBDIR="/$(echo =$(vcgencmd get_config os_prefix) | cut -d'=' -f3)"
+else
+	CUR_FW_SUBDIR="/"
+fi
 FW_SUBDIR=${FW_SUBDIR:-${CUR_FW_SUBDIR}}
 if [[ "${FW_SUBDIR}" != "" ]]; then
 	if [[ "${FW_SUBDIR::1}" != "/" ]]; then

--- a/rpi-update
+++ b/rpi-update
@@ -436,7 +436,7 @@ function do_update {
 	if [ -f ${FW_PATH}/kernel8.img ]; then
 		WANT_64BIT=${WANT_64BIT:-1}
 	fi
-	if [ -f ${FW_PATH}/start4.elf ]; then
+	if [ -f ${FW_PATH}/start4.elf ] || [ -f ${BOOT_PATH}/start4.elf ]; then
 		WANT_PI4=${WANT_PI4:-1}
 	fi
 	WANT_32BIT=${WANT_32BIT:-0}

--- a/rpi-update
+++ b/rpi-update
@@ -133,7 +133,7 @@ function update_modules {
 
 		if [[ ${PRUNE_MODULES} -ne 0 ]]; then
 			find "${FW_MODPATH}" -mindepth 1 -maxdepth 1 -type d | while read DIR; do
-				COUNT=$(find "${DIR}" -type f ! \( -name '*.ko' -o -name 'modules.*' \) | wc -l);
+				COUNT=$(find "${DIR}" -type f ! \( -name '*.ko' -o -name '*.ko.xz' -o -name 'modules.*' \) | wc -l);
 				if [[ ${COUNT} -eq 0 ]]; then
 					echo "Pruning ${DIR}"
 					rm -rf "${DIR}"

--- a/rpi-update
+++ b/rpi-update
@@ -51,7 +51,6 @@ SKIP_DOWNLOAD=${SKIP_DOWNLOAD:-0}
 SKIP_WARNING=${SKIP_WARNING:-0}
 SKIP_CHECK_PARTITION=${SKIP_CHECK_PARTITION:-0}
 WANT_SYMVERS=${WANT_SYMVERS:-0}
-WANT_PI4=${WANT_PI4:-0}
 PRUNE_MODULES=${PRUNE_MODULES:-0}
 RPI_UPDATE_UNSUPPORTED=${RPI_UPDATE_UNSUPPORTED:-0}
 JUST_CHECK=${JUST_CHECK:-0}
@@ -149,13 +148,20 @@ function update_modules {
 
 		find "${FW_REPOLOCAL}/modules" -mindepth 1 -maxdepth 1 -type d | while read DIR; do
 			BASEDIR="$(basename "${DIR}")"
-			if [[ ${WANT_PI4} -ne 1 ]]; then
-				ENDSWITH=${BASEDIR: -4}
-				if [[ "${ENDSWITH}" == "v7l+" ]]; then
+			# get the v7l from 5.15.78-v7l+ and null from 5.15.78+
+			VERSION=$(echo $BASEDIR | cut -sd "-" -f2)
+			if [[ ${WANT_32BIT} -ne 1 ]]; then
+				if [[ "${VERSION}" == "" ]] || [[ "${VERSION}" == "v7+" ]] || [[ "${VERSION}" == "v7l+" ]]; then
 					continue;
 				fi
-				ENDSWITH=${BASEDIR: -3}
-				if [[ "${ENDSWITH}" == "v8+" ]]; then
+			fi
+			if [[ ${WANT_64BIT} -ne 1 ]]; then
+				if [[ "${VERSION}" == "v8+" ]]; then
+					continue;
+				fi
+			fi
+			if [[ ${WANT_PI4} -ne 1 ]]; then
+				if [[ "${VERSION}" == "v7l+" ]]; then
 					continue;
 				fi
 			fi
@@ -336,6 +342,7 @@ function check_partition {
 function update_firmware {
 	echo " *** Updating firmware"
 	rm -rf "${FW_PATH}/"start*.elf
+	rm -rf "${FW_PATH}/"fixup*.dat
 	rm -rf "${FW_PATH}/"bootcode.bin
 	if [[ ${WANT_PI4} -eq 1 ]]; then
 		cp "${FW_REPOLOCAL}/"start*.elf "${FW_PATH}/"
@@ -346,10 +353,14 @@ function update_firmware {
 	fi
 	cp "${FW_REPOLOCAL}/"*.bin "${FW_PATH}/"
 	if [[ ${SKIP_KERNEL} -eq 0 ]]; then
-		if [[ ${WANT_PI4} -eq 1 ]]; then
-			cp "${FW_REPOLOCAL}/"*.img "${FW_PATH}/"
-		else
+		if [[ ${WANT_32BIT} -eq 1 ]]; then
 			cp "${FW_REPOLOCAL}/"kernel.img "${FW_REPOLOCAL}/"kernel7.img "${FW_PATH}/"
+			if [[ ${WANT_PI4} -eq 1 ]]; then
+				cp "${FW_REPOLOCAL}/"kernel7l.img "${FW_PATH}/"
+			fi
+		fi
+		if [[ ${WANT_64BIT} -eq 1 ]]; then
+			cp "${FW_REPOLOCAL}/"kernel8.img "${FW_PATH}/"
 		fi
 		if [[ -n $(shopt -s nullglob; echo "${FW_REPOLOCAL}/"*.dtb*) ]]; then
 			cp "${FW_REPOLOCAL}/"*.dtb* "${FW_PATH}/"
@@ -416,9 +427,22 @@ function do_backup {
 }
 
 function do_update {
-	if [ -f ${FW_PATH}/kernel7l.img ] || [ -f ${FW_PATH}/kernel8.img ]; then
-		WANT_PI4=1
+	if [ -f ${FW_PATH}/kernel.img ] || [ -f ${FW_PATH}/kernel7.img ]; then
+		WANT_32BIT=${WANT_32BIT:-1}
 	fi
+	if [ -f ${FW_PATH}/kernel7l.img ]; then
+		WANT_32BIT=${WANT_32BIT:-1}
+	fi
+	if [ -f ${FW_PATH}/kernel8.img ]; then
+		WANT_64BIT=${WANT_64BIT:-1}
+	fi
+	if [ -f ${FW_PATH}/start4.elf ]; then
+		WANT_PI4=${WANT_PI4:-1}
+	fi
+	WANT_32BIT=${WANT_32BIT:-0}
+	WANT_64BIT=${WANT_64BIT:-0}
+	WANT_PI4=${WANT_PI4:-0}
+	echo "WANT_32BIT:${WANT_32BIT} WANT_64BIT:${WANT_64BIT} WANT_PI4:${WANT_PI4}"
 	if [[ ${WANT_PI4} -eq 1 ]]; then
 		check_partition
 	fi

--- a/rpi-update
+++ b/rpi-update
@@ -3,12 +3,12 @@
 set -o nounset
 set -o errexit
 
-REPO_URI=${REPO_URI:-"https://github.com/Hexxeh/rpi-firmware"}
+REPO_URI=${REPO_URI:-"https://github.com/raspberrypi/rpi-firmware"}
 REPO_API_URI=${REPO_URI/github.com/api.github.com\/repos}
 REPO_CONTENT_URI=${REPO_URI/github.com/raw.githubusercontent.com}
 
 UPDATE_SELF=${UPDATE_SELF:-1}
-UPDATE_REPO_URI="https://github.com/Hexxeh/rpi-update"
+UPDATE_REPO_URI="https://github.com/raspberrypi/rpi-update"
 UPDATE_REPO_CONTENT_URI=${UPDATE_REPO_URI/github.com/raw.githubusercontent.com}
 UPDATE_URI="${UPDATE_REPO_CONTENT_URI}/master/rpi-update"
 


### PR DESCRIPTION
Now that linux kernel PRs automatically build kernel artifacts,
it could be useful for early testing to update directly from the artifact zip file.

The artifacts are found from linux repo, actions, Pi kernel build tests, workflow link.
Then clock number of artifacts (currently 6) and the specific buld you want (e.g. bcm2711_build)

github doesn't provide easy automatic access to artifact links, but they can be downloaded
and the local zip file can be used with:
`rpi-upate <zip file>`
or you can use a download url (using a different download site, or a github artifact proxy)
`rpi-update <http url>`
